### PR TITLE
Thinkpadキーボード接続時に内蔵キーボード無効化、右コントロールをF12に変更

### DIFF
--- a/karabiner.json
+++ b/karabiner.json
@@ -101,6 +101,22 @@
             ]
           },
           {
+            "description": "右コントロールでDev Tools起動（F12）",
+            "manipulators": [
+              {
+                "from": {
+                  "key_code": "right_control"
+                },
+                "to": [
+                  {
+                    "key_code": "f12"
+                  }
+                ],
+                "type": "basic"
+              }
+            ]
+          },
+          {
             "description": "コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな） (rev 3)",
             "manipulators": [
               {
@@ -294,7 +310,7 @@
           "treat_as_built_in_keyboard": false
         },
         {
-          "disable_built_in_keyboard_if_exists": false,
+          "disable_built_in_keyboard_if_exists": true,
           "fn_function_keys": [],
           "identifiers": {
             "is_keyboard": true,


### PR DESCRIPTION
## 更新内容
- Thinkpadキーボード接続時に内蔵キーボード無効化
- 右コントロールをF12に変更